### PR TITLE
Add config ternaries for multiple robots

### DIFF
--- a/src/main/java/org/team1540/robot2024/Constants.java
+++ b/src/main/java/org/team1540/robot2024/Constants.java
@@ -11,7 +11,11 @@ import edu.wpi.first.math.util.Units;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
-    public static final Mode currentMode = Robot.isReal() ? Mode.REAL : Mode.SIM;
+    public static final boolean IS_COMPETITION_ROBOT = true;
+    private static final Mode simMode = Mode.SIM; // Can also be Mode.REPLAY
+    
+    
+    public static final Mode currentMode = Robot.isReal() ? Mode.REAL : simMode;
 
     public enum Mode {
         /**
@@ -32,8 +36,14 @@ public final class Constants {
 
     public static final double LOOP_PERIOD_SECS = 0.02;
 
+    public static class SwerveConfig {
+        public static final String CAN_BUS = IS_COMPETITION_ROBOT ? "" : "";
+        public static final int FRONT_LEFT  = IS_COMPETITION_ROBOT ? 3 : 0;
+        public static final int FRONT_RIGHT = IS_COMPETITION_ROBOT ? 4 : 0;
+        public static final int BACK_LEFT   = IS_COMPETITION_ROBOT ? 7 : 0;
+        public static final int BACK_RIGHT  = IS_COMPETITION_ROBOT ? 1 : 0;
+    }
     public static class Drivetrain {
-        public static final String CAN_BUS = "";
         public static final double DRIVE_GEAR_RATIO = (50.0 / 14.0) * (17.0 / 27.0) * (45.0 / 15.0);
         public static final double TURN_GEAR_RATIO = 150.0 / 7.0;
         public static final boolean IS_TURN_MOTOR_INVERTED = true;

--- a/src/main/java/org/team1540/robot2024/RobotContainer.java
+++ b/src/main/java/org/team1540/robot2024/RobotContainer.java
@@ -8,12 +8,15 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+
+
 import org.team1540.robot2024.commands.FeedForwardCharacterization;
 import org.team1540.robot2024.commands.SwerveDriveCommand;
 import org.team1540.robot2024.subsystems.drive.*;
 import org.team1540.robot2024.util.swerve.SwerveFactory;
 import org.littletonrobotics.junction.networktables.LoggedDashboardChooser;
 
+import static org.team1540.robot2024.Constants.SwerveConfig;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -42,10 +45,10 @@ public class RobotContainer {
                 drivetrain =
                         new Drivetrain(
                                 new GyroIONavx(),
-                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(3, SwerveFactory.SwerveCorner.FRONT_LEFT)),
-                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(4, SwerveFactory.SwerveCorner.FRONT_RIGHT)),
-                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(7, SwerveFactory.SwerveCorner.BACK_LEFT)),
-                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(1, SwerveFactory.SwerveCorner.BACK_RIGHT)));
+                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(SwerveConfig.FRONT_LEFT, SwerveFactory.SwerveCorner.FRONT_LEFT)),
+                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(SwerveConfig.FRONT_RIGHT, SwerveFactory.SwerveCorner.FRONT_RIGHT)),
+                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(SwerveConfig.BACK_LEFT, SwerveFactory.SwerveCorner.BACK_LEFT)),
+                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(SwerveConfig.BACK_RIGHT, SwerveFactory.SwerveCorner.BACK_RIGHT)));
                 break;
 
             case SIM:

--- a/src/main/java/org/team1540/robot2024/util/swerve/SwerveFactory.java
+++ b/src/main/java/org/team1540/robot2024/util/swerve/SwerveFactory.java
@@ -8,7 +8,7 @@ import com.ctre.phoenix6.signals.AbsoluteSensorRangeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.SensorDirectionValue;
 import edu.wpi.first.math.geometry.Rotation2d;
-import org.team1540.robot2024.Constants;
+import static org.team1540.robot2024.Constants.SwerveConfig.CAN_BUS;;
 
 public class SwerveFactory {
     private static final double[] moduleOffsetsRots = new double[]{
@@ -23,7 +23,7 @@ public class SwerveFactory {
     };
 
     public static SwerveModuleHW getModuleMotors(int id, SwerveCorner corner) {
-        return new SwerveModuleHW(id, corner, Constants.Drivetrain.CAN_BUS);
+        return new SwerveModuleHW(id, corner, CAN_BUS);
     }
 
     public enum SwerveCorner {


### PR DESCRIPTION
simplifies the process of switching CAN IDs and whatever else we end up needing to adjust switching between competition and test robots