### PR TITLE
(maybe) easier subsystems

### DIFF
--- a/src/main/java/org/team1540/robot2024/RobotContainer.java
+++ b/src/main/java/org/team1540/robot2024/RobotContainer.java
@@ -11,7 +11,6 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 
-import org.littletonrobotics.junction.Logger;
 import org.team1540.robot2024.Constants.Elevator.ElevatorState;
 import org.team1540.robot2024.commands.FeedForwardCharacterization;
 import org.team1540.robot2024.commands.DriveWithSpeakerTargetingCommand;
@@ -29,9 +28,6 @@ import org.team1540.robot2024.subsystems.led.patterns.LedPatternFlame;
 import org.team1540.robot2024.subsystems.shooter.*;
 import org.team1540.robot2024.subsystems.tramp.Tramp;
 import org.team1540.robot2024.subsystems.vision.AprilTagVision;
-import org.team1540.robot2024.subsystems.vision.AprilTagVisionIO;
-import org.team1540.robot2024.subsystems.vision.AprilTagVisionIOLimelight;
-import org.team1540.robot2024.subsystems.vision.AprilTagVisionIOSim;
 import org.team1540.robot2024.util.auto.AutoCommand;
 import org.team1540.robot2024.util.auto.AutoManager;
 import org.team1540.robot2024.util.PhoenixTimeSyncSignalRefresher;
@@ -58,7 +54,6 @@ public class RobotContainer {
     // Controller
     public final CommandXboxController driver = new CommandXboxController(0);
     public final CommandXboxController copilot = new CommandXboxController(1);
-
 
     public final PhoenixTimeSyncSignalRefresher odometrySignalRefresher = new PhoenixTimeSyncSignalRefresher(SwerveConfig.CAN_BUS);
 

--- a/src/main/java/org/team1540/robot2024/RobotContainer.java
+++ b/src/main/java/org/team1540/robot2024/RobotContainer.java
@@ -16,7 +16,6 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 import org.littletonrobotics.junction.Logger;
-import org.littletonrobotics.junction.networktables.LoggedDashboardChooser;
 import org.team1540.robot2024.Constants.Elevator.ElevatorState;
 import org.team1540.robot2024.commands.FeedForwardCharacterization;
 import org.team1540.robot2024.commands.DriveWithSpeakerTargetingCommand;
@@ -28,28 +27,15 @@ import org.team1540.robot2024.commands.shooter.ShootSequence;
 import org.team1540.robot2024.commands.autos.*;
 import org.team1540.robot2024.subsystems.drive.*;
 import org.team1540.robot2024.subsystems.elevator.Elevator;
-import org.team1540.robot2024.subsystems.elevator.ElevatorIO;
-import org.team1540.robot2024.subsystems.elevator.ElevatorIOSim;
-import org.team1540.robot2024.subsystems.elevator.ElevatorIOTalonFX;
 import org.team1540.robot2024.subsystems.indexer.Indexer;
-import org.team1540.robot2024.subsystems.indexer.IndexerIO;
-import org.team1540.robot2024.subsystems.indexer.IndexerIOSim;
-import org.team1540.robot2024.subsystems.indexer.IndexerIOSparkMax;
 import org.team1540.robot2024.subsystems.led.Leds;
 import org.team1540.robot2024.subsystems.led.patterns.LedPatternFlame;
 import org.team1540.robot2024.subsystems.shooter.*;
 import org.team1540.robot2024.subsystems.tramp.Tramp;
-import org.team1540.robot2024.subsystems.tramp.TrampIO;
-import org.team1540.robot2024.subsystems.tramp.TrampIOSim;
-import org.team1540.robot2024.subsystems.tramp.TrampIOSparkMax;
 import org.team1540.robot2024.subsystems.vision.AprilTagVision;
-import org.team1540.robot2024.subsystems.vision.AprilTagVisionIO;
-import org.team1540.robot2024.subsystems.vision.AprilTagVisionIOLimelight;
-import org.team1540.robot2024.subsystems.vision.AprilTagVisionIOSim;
 import org.team1540.robot2024.util.AutoCommand;
 import org.team1540.robot2024.util.AutoManager;
 import org.team1540.robot2024.util.PhoenixTimeSyncSignalRefresher;
-import org.team1540.robot2024.util.swerve.SwerveFactory;
 import org.team1540.robot2024.util.vision.VisionPoseAcceptor;
 
 import static org.team1540.robot2024.Constants.SwerveConfig;
@@ -89,26 +75,15 @@ public class RobotContainer {
         switch (Constants.currentMode) {
             case REAL:
                 // Real robot, instantiate hardware IO implementations
-                drivetrain =
-                        new Drivetrain(
-                                new GyroIOPigeon2(odometrySignalRefresher),
-                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(SwerveConfig.FRONT_LEFT, SwerveFactory.SwerveCorner.FRONT_LEFT), odometrySignalRefresher),
-                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(SwerveConfig.FRONT_RIGHT, SwerveFactory.SwerveCorner.FRONT_RIGHT), odometrySignalRefresher),
-                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(SwerveConfig.BACK_LEFT, SwerveFactory.SwerveCorner.BACK_LEFT), odometrySignalRefresher),
-                                new ModuleIOTalonFX(SwerveFactory.getModuleMotors(SwerveConfig.BACK_RIGHT, SwerveFactory.SwerveCorner.BACK_RIGHT), odometrySignalRefresher));
-                tramp = new Tramp(new TrampIOSparkMax());
-                shooter = new Shooter(new ShooterPivotIOTalonFX(), new FlywheelsIOTalonFX());
-                elevator = new Elevator(new ElevatorIOTalonFX());
-                indexer =
-                        new Indexer(
-                                new IndexerIOSparkMax()
-                        );
-                aprilTagVision = new AprilTagVision(
-                        new AprilTagVisionIOLimelight(Constants.Vision.FRONT_CAMERA_NAME, Constants.Vision.FRONT_CAMERA_POSE),
-                        new AprilTagVisionIOLimelight(Constants.Vision.REAR_CAMERA_NAME, Constants.Vision.REAR_CAMERA_POSE),
+                drivetrain = Drivetrain.createReal(odometrySignalRefresher);
+                tramp = Tramp.createReal();
+                shooter = Shooter.createReal();
+                elevator = Elevator.createReal();
+                indexer = Indexer.createReal();
+                aprilTagVision = AprilTagVision.createReal(
                         drivetrain::addVisionMeasurement,
-                        () -> 0.0, // TODO: ACTUALLY GET ELEVATOR HEIGHT HERE
-                        new VisionPoseAcceptor(drivetrain::getChassisSpeeds, () -> 0.0)); // TODO: ACTUALLY GET ELEVATOR VELOCITY HERE
+                        elevator::getPosition,
+                        new VisionPoseAcceptor(drivetrain::getChassisSpeeds, () -> 0.0));
 
                 PathPlannerLogging.setLogCurrentPoseCallback((pose) -> {
                     Logger.recordOutput("PathPlanner/Position", pose);
@@ -124,31 +99,19 @@ public class RobotContainer {
                         Logger.recordOutput("PathPlanner/ActivePath", currentPathTrajectory);
                     }
                 });
-
                 break;
             case SIM:
                 // Sim robot, instantiate physics sim IO implementations
-                drivetrain =
-                        new Drivetrain(
-                                new GyroIO() {},
-                                new ModuleIOSim(),
-                                new ModuleIOSim(),
-                                new ModuleIOSim(),
-                                new ModuleIOSim());
-                tramp = new Tramp(new TrampIOSim());
-                shooter = new Shooter(new ShooterPivotIOSim(), new FlywheelsIOSim());
-                elevator = new Elevator(new ElevatorIOSim());
-                aprilTagVision =
-                        new AprilTagVision(
-                                new AprilTagVisionIOSim(Constants.Vision.FRONT_CAMERA_NAME, Constants.Vision.FRONT_CAMERA_POSE, drivetrain::getPose),
-                                new AprilTagVisionIOSim(Constants.Vision.REAR_CAMERA_NAME, Constants.Vision.REAR_CAMERA_POSE, drivetrain::getPose),
-                                ignored -> {},
-                                () -> 0.0, // TODO: ACTUALLY GET ELEVATOR HEIGHT HERE
-                                new VisionPoseAcceptor(drivetrain::getChassisSpeeds, () -> 0.0)); // TODO: ACTUALLY GET ELEVATOR VELOCITY HERE
-                indexer =
-                        new Indexer(
-                                new IndexerIOSim()
-                        );
+                drivetrain = Drivetrain.createSim();
+                tramp = Tramp.createSim();
+                shooter = Shooter.createSim();
+                elevator = Elevator.createSim();
+                indexer = Indexer.createSim();
+                aprilTagVision = AprilTagVision.createSim(
+                        drivetrain::addVisionMeasurement,
+                        drivetrain::getPose,
+                        elevator::getPosition,
+                        new VisionPoseAcceptor(drivetrain::getChassisSpeeds, () -> 0.0));
 
                 PathPlannerLogging.setLogTargetPoseCallback((pose) -> {
                     Logger.recordOutput("PathPlanner/Position", pose);
@@ -166,31 +129,14 @@ public class RobotContainer {
                 break;
             default:
                 // Replayed robot, disable IO implementations
-                drivetrain =
-                        new Drivetrain(
-                                new GyroIO() {},
-                                new ModuleIO() {},
-                                new ModuleIO() {},
-                                new ModuleIO() {},
-                                new ModuleIO() {});
-                shooter = new Shooter(new ShooterPivotIO() {}, new FlywheelsIO() {});
-                elevator = new Elevator(new ElevatorIO() {});
-                aprilTagVision =
-                        new AprilTagVision(
-                                new AprilTagVisionIO() {},
-                                new AprilTagVisionIO() {},
-                                (ignored) -> {},
-                                () -> 0.0,
-                                new VisionPoseAcceptor(drivetrain::getChassisSpeeds, () -> 0.0)
-                        );
-
-                indexer = new Indexer(new IndexerIO() {});
-                tramp = new Tramp(new TrampIO() {});
-
+                drivetrain = Drivetrain.createDummy();
+                tramp = Tramp.createDummy();
+                shooter = Shooter.createDummy();
+                elevator = Elevator.createDummy();
+                indexer = Indexer.createDummy();
+                aprilTagVision = AprilTagVision.createDummy();
                 break;
         }
-
-
 
         // Set up FF characterization routines
         AutoManager.getInstance().addAuto(

--- a/src/main/java/org/team1540/robot2024/subsystems/drive/Drivetrain.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/drive/Drivetrain.java
@@ -81,6 +81,9 @@ public class Drivetrain extends SubsystemBase {
     }
 
     public static Drivetrain createReal(PhoenixTimeSyncSignalRefresher odometrySignalRefresher) {
+        if (Constants.currentMode != Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using real drivetrain on simulated robot", false);
+        }
         return new Drivetrain(
                 new GyroIOPigeon2(odometrySignalRefresher),
                 new ModuleIOTalonFX(SwerveFactory.getModuleMotors(Constants.SwerveConfig.FRONT_LEFT, SwerveFactory.SwerveCorner.FRONT_LEFT), odometrySignalRefresher),
@@ -90,6 +93,9 @@ public class Drivetrain extends SubsystemBase {
     }
 
     public static Drivetrain createSim() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using simulated drivetrain on real robot", false);
+        }
         return new Drivetrain(
                 new GyroIO() {},
                 new ModuleIOSim(),
@@ -99,6 +105,9 @@ public class Drivetrain extends SubsystemBase {
     }
 
     public static Drivetrain createDummy() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using dummy drivetrain on real robot", false);
+        }
         return new Drivetrain(
                 new GyroIO() {},
                 new ModuleIO() {},

--- a/src/main/java/org/team1540/robot2024/subsystems/elevator/Elevator.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/elevator/Elevator.java
@@ -1,6 +1,7 @@
 package org.team1540.robot2024.subsystems.elevator;
 
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
@@ -25,14 +26,23 @@ public class Elevator extends SubsystemBase {
     }
 
     public static Elevator createReal() {
+        if (Constants.currentMode != Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using real elevator on simulated robot", false);
+        }
         return new Elevator(new ElevatorIOTalonFX());
     }
 
     public static Elevator createSim() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using simulated elevator on real robot", false);
+        }
         return new Elevator(new ElevatorIOSim());
     }
 
     public static Elevator createDummy() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using dummy elevator on real robot", false);
+        }
         return new Elevator(new ElevatorIO(){});
     }
 

--- a/src/main/java/org/team1540/robot2024/subsystems/elevator/Elevator.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/elevator/Elevator.java
@@ -16,9 +16,24 @@ public class Elevator extends SubsystemBase {
     private final AverageFilter positionFilter = new AverageFilter(10);
     private double setpointMeters;
 
+    private static boolean hasInstance = false;
 
-    public Elevator(ElevatorIO elevatorIO) {
+    private Elevator(ElevatorIO elevatorIO) {
+        if (hasInstance) throw new IllegalStateException("Instance of elevator already exists");
+        hasInstance = true;
         this.io = elevatorIO;
+    }
+
+    public static Elevator createReal() {
+        return new Elevator(new ElevatorIOTalonFX());
+    }
+
+    public static Elevator createSim() {
+        return new Elevator(new ElevatorIOSim());
+    }
+
+    public static Elevator createDummy() {
+        return new Elevator(new ElevatorIO(){});
     }
 
     // periodic
@@ -55,5 +70,7 @@ public class Elevator extends SubsystemBase {
         return setpointMeters;
     }
 
-
+    public double getPosition() {
+        return inputs.positionMeters;
+    }
 }

--- a/src/main/java/org/team1540/robot2024/subsystems/indexer/Indexer.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/indexer/Indexer.java
@@ -1,5 +1,6 @@
 package org.team1540.robot2024.subsystems.indexer;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
@@ -28,14 +29,23 @@ public class Indexer extends SubsystemBase {
     }
 
     public static Indexer createReal() {
+        if (Constants.currentMode != Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using real indexer on simulated robot", false);
+        }
         return new Indexer(new IndexerIOSparkMax());
     }
 
     public static Indexer createSim() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using simulated indexer on real robot", false);
+        }
         return new Indexer(new IndexerIOSim());
     }
 
     public static Indexer createDummy() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using dummy indexer on real robot", false);
+        }
         return new Indexer(new IndexerIO(){});
     }
 

--- a/src/main/java/org/team1540/robot2024/subsystems/indexer/Indexer.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/indexer/Indexer.java
@@ -14,13 +14,29 @@ import static org.team1540.robot2024.Constants.Indexer.*;
 public class Indexer extends SubsystemBase {
     private final IndexerIO io;
     private final IndexerIOInputsAutoLogged inputs = new IndexerIOInputsAutoLogged();
+
     private final LoggedTunableNumber kP = new LoggedTunableNumber("Indexer/kP", FEEDER_KP);
     private final LoggedTunableNumber kI = new LoggedTunableNumber("Indexer/kI", FEEDER_KI);
     private final LoggedTunableNumber kD = new LoggedTunableNumber("Indexer/kD", FEEDER_KD);
 
+    private static boolean hasInstance = false;
 
-    public Indexer(IndexerIO io) {
+    private Indexer(IndexerIO io) {
+        if (hasInstance) throw new IllegalStateException("Instance of indexer already exists");
+        hasInstance = true;
         this.io = io;
+    }
+
+    public static Indexer createReal() {
+        return new Indexer(new IndexerIOSparkMax());
+    }
+
+    public static Indexer createSim() {
+        return new Indexer(new IndexerIOSim());
+    }
+
+    public static Indexer createDummy() {
+        return new Indexer(new IndexerIO(){});
     }
 
     public void periodic() {

--- a/src/main/java/org/team1540/robot2024/subsystems/shooter/Shooter.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/shooter/Shooter.java
@@ -38,9 +38,25 @@ public class Shooter extends SubsystemBase {
     private final LoggedTunableNumber pivotKI = new LoggedTunableNumber("Shooter/Pivot/kI", Pivot.KI);
     private final LoggedTunableNumber pivotKD = new LoggedTunableNumber("Shooter/Pivot/kD", Pivot.KD);
 
-    public Shooter(ShooterPivotIO pivotIO, FlywheelsIO flywheelsIO) {
+    private static boolean hasInstance = false;
+
+    private Shooter(ShooterPivotIO pivotIO, FlywheelsIO flywheelsIO) {
+        if (hasInstance) throw new IllegalStateException("Instance of shooter already exists");
+        hasInstance = true;
         this.pivotIO = pivotIO;
         this.flywheelsIO = flywheelsIO;
+    }
+
+    public static Shooter createReal() {
+        return new Shooter(new ShooterPivotIOTalonFX(), new FlywheelsIOTalonFX());
+    }
+
+    public static Shooter createSim() {
+        return new Shooter(new ShooterPivotIOSim(), new FlywheelsIOSim());
+    }
+
+    public static Shooter createDummy() {
+        return new Shooter(new ShooterPivotIO(){}, new FlywheelsIO(){});
     }
 
     @Override

--- a/src/main/java/org/team1540/robot2024/subsystems/shooter/Shooter.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/shooter/Shooter.java
@@ -2,10 +2,12 @@ package org.team1540.robot2024.subsystems.shooter;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.Logger;
+import org.team1540.robot2024.Constants;
 import org.team1540.robot2024.util.LoggedTunableNumber;
 import org.team1540.robot2024.util.MechanismVisualiser;
 import org.team1540.robot2024.util.math.AverageFilter;
@@ -48,14 +50,23 @@ public class Shooter extends SubsystemBase {
     }
 
     public static Shooter createReal() {
+        if (Constants.currentMode != Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using real shooter on simulated robot", false);
+        }
         return new Shooter(new ShooterPivotIOTalonFX(), new FlywheelsIOTalonFX());
     }
 
     public static Shooter createSim() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using simulated shooter on real robot", false);
+        }
         return new Shooter(new ShooterPivotIOSim(), new FlywheelsIOSim());
     }
 
     public static Shooter createDummy() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using dummy shooter on real robot", false);
+        }
         return new Shooter(new ShooterPivotIO(){}, new FlywheelsIO(){});
     }
 

--- a/src/main/java/org/team1540/robot2024/subsystems/tramp/Tramp.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/tramp/Tramp.java
@@ -7,8 +7,24 @@ public class Tramp extends SubsystemBase {
     private final TrampIO io;
     private final TrampIOInputsAutoLogged inputs = new TrampIOInputsAutoLogged();
 
-    public Tramp(TrampIO io) {
+    private static boolean hasInstance = false;
+
+    private Tramp(TrampIO io) {
+        if (hasInstance) throw new IllegalStateException("Instance of tramp already exists");
+        hasInstance = true;
         this.io = io;
+    }
+
+    public static Tramp createReal() {
+        return new Tramp(new TrampIOSparkMax());
+    }
+
+    public static Tramp createSim() {
+        return new Tramp(new TrampIOSim());
+    }
+
+    public static Tramp createDummy() {
+        return new Tramp(new TrampIO(){});
     }
 
     public void setPercent(double percentage) {

--- a/src/main/java/org/team1540/robot2024/subsystems/tramp/Tramp.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/tramp/Tramp.java
@@ -1,7 +1,9 @@
 package org.team1540.robot2024.subsystems.tramp;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.Logger;
+import org.team1540.robot2024.Constants;
 
 public class Tramp extends SubsystemBase {
     private final TrampIO io;
@@ -16,14 +18,23 @@ public class Tramp extends SubsystemBase {
     }
 
     public static Tramp createReal() {
+        if (Constants.currentMode != Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using real tramp on simulated robot", false);
+        }
         return new Tramp(new TrampIOSparkMax());
     }
 
     public static Tramp createSim() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using simulated tramp on real robot", false);
+        }
         return new Tramp(new TrampIOSim());
     }
 
     public static Tramp createDummy() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using dummy tramp on real robot", false);
+        }
         return new Tramp(new TrampIO(){});
     }
 

--- a/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVision.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVision.java
@@ -3,8 +3,10 @@ package org.team1540.robot2024.subsystems.vision;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.Logger;
+import org.team1540.robot2024.Constants;
 import org.team1540.robot2024.util.vision.TimestampedVisionPose;
 import org.team1540.robot2024.util.vision.VisionPoseAcceptor;
 
@@ -52,6 +54,9 @@ public class AprilTagVision extends SubsystemBase {
     public static AprilTagVision createReal(Consumer<TimestampedVisionPose> visionPoseConsumer,
                                             Supplier<Double> elevatorHeightSupplierMeters,
                                             VisionPoseAcceptor poseAcceptor) {
+        if (Constants.currentMode != Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using real vision on simulated robot", false);
+        }
         return new AprilTagVision(
                 new AprilTagVisionIOLimelight(FRONT_CAMERA_NAME, FRONT_CAMERA_POSE),
                 new AprilTagVisionIOLimelight(REAR_CAMERA_NAME, REAR_CAMERA_POSE),
@@ -64,6 +69,9 @@ public class AprilTagVision extends SubsystemBase {
                                            Supplier<Pose2d> drivetrainPoseSupplier,
                                            Supplier<Double> elevatorHeightSupplierMeters,
                                            VisionPoseAcceptor poseAcceptor) {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using simulated vision on real robot", false);
+        }
         return new AprilTagVision(
                 new AprilTagVisionIOSim(FRONT_CAMERA_NAME, FRONT_CAMERA_POSE, drivetrainPoseSupplier),
                 new AprilTagVisionIOSim(REAR_CAMERA_NAME, REAR_CAMERA_POSE, drivetrainPoseSupplier),
@@ -73,6 +81,9 @@ public class AprilTagVision extends SubsystemBase {
     }
 
     public static AprilTagVision createDummy() {
+        if (Constants.currentMode == Constants.Mode.REAL) {
+            DriverStation.reportWarning("Using dummy vision on real robot", false);
+        }
         return new AprilTagVision(
                 new AprilTagVisionIO() {},
                 new AprilTagVisionIO() {},


### PR DESCRIPTION
Makes disabling subsystems and using dummy IOs easier
- Each subsystem has methods to create an instance using real, sim, and dummy IOs
- To disable a subsystem on the robot, just change `Subsystem.createReal()` to `Subsystem.createDummy()` in RobotContainer
- Throws an exception if more than one of each subsystem is initialized
- Reports a DS warning if a sim or dummy subsystem is initialized when in real mode, and vice-versa