### PR TITLE
Driver dashboard alerts

### DIFF
--- a/src/main/java/org/team1540/robot2024/AlertManager.java
+++ b/src/main/java/org/team1540/robot2024/AlertManager.java
@@ -1,0 +1,80 @@
+package org.team1540.robot2024;
+
+import com.ctre.phoenix6.CANBus;
+import edu.wpi.first.hal.can.CANStatus;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.Timer;
+import org.team1540.robot2024.util.Alert;
+
+/**
+ * Class for managing high-level robot alerts, such as low battery and CAN bus errors. Subsystem-specific alerts,
+ * such as motor disconnects, should be handled by their respective subsystems.
+ */
+public class AlertManager {
+    private static AlertManager instance;
+
+    public static AlertManager getInstance() {
+        if (instance == null) instance = new AlertManager();
+        return instance;
+    }
+
+    private static final double lowBatteryDisableTime = 1.5;
+    private static final double lowBatteryVoltageThreshold = 12.0;
+    private static final double canErrorTimeThreshold = 0.5;
+
+    private final Timer disabledTimer = new Timer();
+    private final Timer canInitialErrorTimer = new Timer();
+    private final Timer canErrorTimer = new Timer();
+    private final Timer canivoreErrorTimer = new Timer();
+
+    private int lastRioCanTEC = 0;
+    private int lastRioCanREC = 0;
+    private int lastCanivoreTEC = 0;
+    private int lastCanivoreREC = 0;
+
+    private final Alert canErrorAlert =
+            new Alert("RIO CAN bus error, robot functionality may be severely limited", Alert.AlertType.ERROR);
+    private final Alert canivoreErrorAlert =
+            new Alert("Swerve CAN bus error, drive functionality may be severely limited", Alert.AlertType.ERROR);
+    private final Alert lowBatteryAlert =
+            new Alert("Battery voltage is low, consider replacing it", Alert.AlertType.WARNING);
+
+    public void start() {
+        disabledTimer.restart();
+        canErrorTimer.restart();
+        canivoreErrorTimer.restart();
+        canInitialErrorTimer.restart();
+    }
+
+    public void update() {
+        // Update timers
+        CANStatus rioCanStatus = RobotController.getCANStatus();
+        if (rioCanStatus.transmitErrorCount > lastRioCanTEC || rioCanStatus.receiveErrorCount > lastRioCanREC) {
+            canErrorTimer.reset();
+        }
+        lastRioCanTEC = rioCanStatus.transmitErrorCount;
+        lastRioCanREC = rioCanStatus.receiveErrorCount;
+
+        CANBus.CANBusStatus canivoreStatus = CANBus.getStatus(Constants.SwerveConfig.CAN_BUS);
+        if (!canivoreStatus.Status.isOK()
+                || canivoreStatus.TEC > lastCanivoreTEC
+                || canivoreStatus.REC > lastCanivoreREC) {
+            canivoreErrorTimer.reset();
+        }
+        lastCanivoreTEC = canivoreStatus.TEC;
+        lastCanivoreREC = canivoreStatus.REC;
+
+        if (DriverStation.isEnabled()) disabledTimer.reset();
+
+        canErrorAlert.set(
+                !canErrorTimer.hasElapsed(canErrorTimeThreshold)
+                        && canInitialErrorTimer.hasElapsed(canErrorTimeThreshold));
+        canivoreErrorAlert.set(
+                !canivoreErrorTimer.hasElapsed(canErrorTimeThreshold)
+                        && canInitialErrorTimer.hasElapsed(canErrorTimeThreshold));
+        lowBatteryAlert.set(
+                RobotController.getBatteryVoltage() < lowBatteryVoltageThreshold
+                        && disabledTimer.hasElapsed(lowBatteryDisableTime));
+    }
+}

--- a/src/main/java/org/team1540/robot2024/Robot.java
+++ b/src/main/java/org/team1540/robot2024/Robot.java
@@ -92,6 +92,8 @@ public class Robot extends LoggedRobot {
         // Start AdvantageKit logger
         Logger.start();
 
+        AlertManager.getInstance().start();
+
         DriverStation.silenceJoystickConnectionWarning(true);
 
         // Instantiate our RobotContainer. This will perform all our button bindings,
@@ -122,6 +124,7 @@ public class Robot extends LoggedRobot {
         // the Command-based framework to work.
         CommandScheduler.getInstance().run();
         if (Constants.currentMode == Constants.Mode.REAL) robotContainer.odometrySignalRefresher.periodic();
+        AlertManager.getInstance().update();
 
         // Update mechanism visualiser in sim
         if (Robot.isSimulation()) MechanismVisualiser.periodic();

--- a/src/main/java/org/team1540/robot2024/RobotContainer.java
+++ b/src/main/java/org/team1540/robot2024/RobotContainer.java
@@ -57,8 +57,6 @@ public class RobotContainer {
 
     public final PhoenixTimeSyncSignalRefresher odometrySignalRefresher = new PhoenixTimeSyncSignalRefresher(SwerveConfig.CAN_BUS);
 
-
-
     public boolean isBrakeMode;
     /**
      * The container for the robot. Contains subsystems, IO devices, and commands.

--- a/src/main/java/org/team1540/robot2024/RobotContainer.java
+++ b/src/main/java/org/team1540/robot2024/RobotContainer.java
@@ -30,6 +30,7 @@ import org.team1540.robot2024.subsystems.led.patterns.*;
 import org.team1540.robot2024.subsystems.shooter.Shooter;
 import org.team1540.robot2024.subsystems.tramp.Tramp;
 import org.team1540.robot2024.subsystems.vision.AprilTagVision;
+import org.team1540.robot2024.util.Alert;
 import org.team1540.robot2024.util.CommandUtils;
 import org.team1540.robot2024.util.PhoenixTimeSyncSignalRefresher;
 import org.team1540.robot2024.util.auto.AutoCommand;
@@ -242,26 +243,25 @@ public class RobotContainer {
         AutoManager autos = AutoManager.getInstance();
         // Set up FF characterization routines
         if (isTuningMode()) {
-            AutoManager.getInstance().add(
-                    new AutoCommand(
-                            "Drive FF Characterization",
-                            new FeedForwardCharacterization(
-                                    drivetrain, drivetrain::runCharacterizationVolts, drivetrain::getCharacterizationVelocity
-                            )
-                    )
-            );
-
-            AutoManager.getInstance().add(
-                    new AutoCommand(
-                            "Flywheels FF Characterization",
-                            new FeedForwardCharacterization(
-                                    shooter, volts -> shooter.setFlywheelVolts(volts, volts), () -> shooter.getLeftFlywheelSpeed() / 60
-                            )
-                    )
-            );
-
+            new Alert("Tuning mode enabled", Alert.AlertType.INFO).set(true);
+            autos.add(new AutoCommand(
+                    "Drive FF Characterization",
+                    new FeedForwardCharacterization(
+                            drivetrain,
+                            drivetrain::runCharacterizationVolts,
+                            drivetrain::getCharacterizationVelocity)));
+            autos.add(new AutoCommand(
+                    "Flywheels FF Characterization",
+                    new FeedForwardCharacterization(
+                            shooter,
+                            volts -> shooter.setFlywheelVolts(volts, volts),
+                            () -> shooter.getLeftFlywheelSpeed() / 60)));
+            autos.add(new AutoCommand(
+                    "WheelRadiusChar",
+                    new WheelRadiusCharacterization(
+                            drivetrain, WheelRadiusCharacterization.Direction.COUNTER_CLOCKWISE)));
         }
-        autos.add(new AutoCommand("WheelRadiusChar", new WheelRadiusCharacterization(drivetrain, WheelRadiusCharacterization.Direction.COUNTER_CLOCKWISE)));
+
         autos.addDefault(new AutoCommand("Dwayne :skull:"));
         autos.add(new AmpLanePADEF(drivetrain, shooter, indexer));
         autos.add(new AmpLanePAEDF(drivetrain, shooter, indexer));

--- a/src/main/java/org/team1540/robot2024/subsystems/drive/Drivetrain.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/drive/Drivetrain.java
@@ -27,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
+import org.team1540.robot2024.Robot;
 import org.team1540.robot2024.util.Alert;
 import org.team1540.robot2024.util.auto.LocalADStarAK;
 import org.team1540.robot2024.Constants;
@@ -195,7 +196,7 @@ public class Drivetrain extends SubsystemBase {
         poseEstimator.update(rawGyroRotation, getModulePositions());
         visionPoseEstimator.update(rawGyroRotation, getModulePositions());
 
-        gyroDisconnected.set(!gyroInputs.connected);
+        gyroDisconnected.set(!gyroInputs.connected && Robot.isReal());
     }
 
     /**

--- a/src/main/java/org/team1540/robot2024/subsystems/drive/Drivetrain.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/drive/Drivetrain.java
@@ -1,7 +1,6 @@
 package org.team1540.robot2024.subsystems.drive;
 
 import com.pathplanner.lib.auto.AutoBuilder;
-import com.pathplanner.lib.commands.FollowPathHolonomic;
 import com.pathplanner.lib.controllers.PPHolonomicDriveController;
 import com.pathplanner.lib.pathfinding.Pathfinding;
 import com.pathplanner.lib.util.HolonomicPathFollowerConfig;
@@ -28,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
+import org.team1540.robot2024.util.Alert;
 import org.team1540.robot2024.util.auto.LocalADStarAK;
 import org.team1540.robot2024.Constants;
 import org.team1540.robot2024.util.PhoenixTimeSyncSignalRefresher;
@@ -63,6 +63,8 @@ public class Drivetrain extends SubsystemBase {
     private double characterizationInput = 0.0;
 
     private Pose2d targetPose = new Pose2d();
+
+    private final Alert gyroDisconnected = new Alert("Gyro disconnected!", Alert.AlertType.WARNING);
 
     private Drivetrain(
             GyroIO gyroIO,
@@ -193,6 +195,7 @@ public class Drivetrain extends SubsystemBase {
         poseEstimator.update(rawGyroRotation, getModulePositions());
         visionPoseEstimator.update(rawGyroRotation, getModulePositions());
 
+        gyroDisconnected.set(!gyroInputs.connected);
     }
 
     /**

--- a/src/main/java/org/team1540/robot2024/subsystems/drive/ModuleIO.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/drive/ModuleIO.java
@@ -11,6 +11,7 @@ public interface ModuleIO {
         public double driveAppliedVolts = 0.0;
         public double driveCurrentAmps = 0.0;
         public double driveTempCelsius = 0.0;
+        public boolean driveMotorConnected = true;
 
         public Rotation2d turnAbsolutePosition = new Rotation2d();
         public Rotation2d turnPosition = new Rotation2d();
@@ -18,6 +19,8 @@ public interface ModuleIO {
         public double turnAppliedVolts = 0.0;
         public double turnCurrentAmps = 0.0;
         public double turnTempCelsius = 0.0;
+        public boolean turnMotorConnected = true;
+        public boolean turnEncoderConnected = true;
     }
 
     /**

--- a/src/main/java/org/team1540/robot2024/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/drive/ModuleIOTalonFX.java
@@ -92,16 +92,17 @@ public class ModuleIOTalonFX implements ModuleIO {
     @Override
     public void updateInputs(ModuleIOInputs inputs) {
         odometrySignalRefresher.refreshSignals();
-        BaseStatusSignal.refreshAll(
+        inputs.driveMotorConnected = BaseStatusSignal.refreshAll(
                 driveVelocity,
                 driveAppliedVolts,
                 driveCurrent,
-                driveTempCelsius,
-                turnAbsolutePosition,
+                driveTempCelsius).isOK();
+        inputs.turnMotorConnected = BaseStatusSignal.refreshAll(
                 turnVelocity,
                 turnAppliedVolts,
                 turnCurrent,
-                turnTempCelsius);
+                turnTempCelsius).isOK();
+        inputs.turnEncoderConnected = BaseStatusSignal.refreshAll(turnAbsolutePosition).isOK();
 
         inputs.drivePositionRad = Units.rotationsToRadians(drivePosition.getValueAsDouble()) / DRIVE_GEAR_RATIO;
         inputs.driveVelocityRadPerSec = Units.rotationsToRadians(driveVelocity.getValueAsDouble()) / DRIVE_GEAR_RATIO;

--- a/src/main/java/org/team1540/robot2024/subsystems/elevator/Elevator.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/elevator/Elevator.java
@@ -7,6 +7,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
 import org.team1540.robot2024.Constants;
+import org.team1540.robot2024.util.Alert;
 import org.team1540.robot2024.util.LoggedTunableNumber;
 import org.team1540.robot2024.util.MechanismVisualiser;
 import org.team1540.robot2024.util.math.AverageFilter;
@@ -23,6 +24,11 @@ public class Elevator extends SubsystemBase {
     private final LoggedTunableNumber kP = new LoggedTunableNumber("Elevator/kP", KP);
     private final LoggedTunableNumber kI = new LoggedTunableNumber("Elevator/kI", KI);
     private final LoggedTunableNumber kD = new LoggedTunableNumber("Elevator/kD", KD);
+
+    private final Alert leadMotorDisconnected =
+            new Alert("Elevator lead motor disconnected!", Alert.AlertType.WARNING);
+    private final Alert followMotorDisconnected =
+            new Alert("Elevator follower motor disconnected!", Alert.AlertType.WARNING);
 
     private static boolean hasInstance = false;
 
@@ -69,6 +75,9 @@ public class Elevator extends SubsystemBase {
         if(getPosition() > 0.31){
             setFlipper(false);
         }
+
+        leadMotorDisconnected.set(!inputs.leadMotorConnected);
+        followMotorDisconnected.set(!inputs.followMotorConnected);
     }
 
     public void setElevatorPosition(double positionMeters) {

--- a/src/main/java/org/team1540/robot2024/subsystems/elevator/ElevatorIO.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/elevator/ElevatorIO.java
@@ -13,6 +13,9 @@ public interface ElevatorIO {
         public boolean atUpperLimit = false;
         public boolean atLowerLimit = false;
         public double flipperAngleDegrees = 0.0;
+
+        public boolean leadMotorConnected = true;
+        public boolean followMotorConnected = true;
     }
 
     default void updateInputs(ElevatorIOInputs inputs) {}

--- a/src/main/java/org/team1540/robot2024/subsystems/elevator/ElevatorIOTalonFX.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/elevator/ElevatorIOTalonFX.java
@@ -28,11 +28,10 @@ public class ElevatorIOTalonFX implements ElevatorIO {
     private final StatusSignal<Double> followerTemp = follower.getDeviceTemp();
     private final StatusSignal<ForwardLimitValue> topLimitStatus = leader.getForwardLimit();
     private final StatusSignal<ReverseLimitValue> bottomLimitStatus = leader.getReverseLimit();
-    TalonFXConfiguration config;
 
 
     public ElevatorIOTalonFX() {
-        config = new TalonFXConfiguration();
+        TalonFXConfiguration config = new TalonFXConfiguration();
         config.CurrentLimits.SupplyCurrentLimitEnable = true;
         config.CurrentLimits.SupplyCurrentLimit = 40.0;
         config.CurrentLimits.SupplyCurrentThreshold = 60.0;
@@ -83,16 +82,15 @@ public class ElevatorIOTalonFX implements ElevatorIO {
 
     @Override
     public void updateInputs(ElevatorIOInputs inputs) {
-        BaseStatusSignal.refreshAll(
+        inputs.leadMotorConnected = BaseStatusSignal.refreshAll(
                 leaderPosition,
                 leaderVelocity,
                 leaderAppliedVolts,
                 leaderCurrent,
-                followerCurrent,
                 leaderTemp,
-                followerTemp,
                 topLimitStatus,
-                bottomLimitStatus);
+                bottomLimitStatus).isOK();
+        inputs.followMotorConnected = BaseStatusSignal.refreshAll(followerCurrent, followerTemp).isOK();
 
         inputs.positionMeters = leaderPosition.getValueAsDouble();
         inputs.velocityMPS = leaderVelocity.getValueAsDouble();

--- a/src/main/java/org/team1540/robot2024/subsystems/indexer/Indexer.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/indexer/Indexer.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
 import org.team1540.robot2024.Constants;
+import org.team1540.robot2024.util.Alert;
 import org.team1540.robot2024.util.LoggedTunableNumber;
 
 import static org.team1540.robot2024.Constants.Indexer.*;
@@ -21,6 +22,9 @@ public class Indexer extends SubsystemBase {
     private final LoggedTunableNumber kP = new LoggedTunableNumber("Indexer/kP", FEEDER_KP);
     private final LoggedTunableNumber kI = new LoggedTunableNumber("Indexer/kI", FEEDER_KI);
     private final LoggedTunableNumber kD = new LoggedTunableNumber("Indexer/kD", FEEDER_KD);
+
+    private final Alert intakeMotorDisconnected = new Alert("Intake motor disconnected!", Alert.AlertType.WARNING);
+    private final Alert feederMotorDisconnected = new Alert("Feeder motor disconnected!", Alert.AlertType.WARNING);
 
     private double feederSetpointRPM = 0.0;
 
@@ -58,9 +62,12 @@ public class Indexer extends SubsystemBase {
         io.updateInputs(inputs);
         Logger.processInputs("Indexer", inputs);
 
-        if (RobotState.isDisabled()){
+        if (RobotState.isDisabled()) {
             stopAll();
         }
+
+        intakeMotorDisconnected.set(!inputs.intakeMotorConnected);
+        feederMotorDisconnected.set(!inputs.feederMotorConnected);
     }
 
     public void setIntakePercent(double percent) {

--- a/src/main/java/org/team1540/robot2024/subsystems/indexer/IndexerIO.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/indexer/IndexerIO.java
@@ -10,10 +10,14 @@ public interface IndexerIO {
         public double intakeCurrentAmps = 0.01;
         public double intakeVelocityRPM = 0.0;
         public double intakeTempCelsius = 0.0;
+        public boolean intakeMotorConnected = true;
+
         public double feederVoltage = 0.0;
         public double feederCurrentAmps = 0.0;
         public double feederVelocityRPM = 0.0;
         public double feederTempCelsius = 0.0;
+        public boolean feederMotorConnected = true;
+
         public boolean noteInIntake = false;
     }
 

--- a/src/main/java/org/team1540/robot2024/subsystems/indexer/IndexerIOTalonFX.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/indexer/IndexerIOTalonFX.java
@@ -70,15 +70,16 @@ public class IndexerIOTalonFX implements IndexerIO {
 
     @Override
     public void updateInputs(IndexerIOInputs inputs) {
-        BaseStatusSignal.refreshAll(
+        inputs.intakeMotorConnected = BaseStatusSignal.refreshAll(
                 intakeVoltage,
                 intakeCurrent,
                 intakeVelocity,
-                intakeTemp,
+                intakeTemp).isOK();
+        inputs.feederMotorConnected = BaseStatusSignal.refreshAll(
                 feederVoltage,
                 feederCurrent,
                 feederVelocity,
-                feederTemp);
+                feederTemp).isOK();
         inputs.intakeVoltage = intakeVoltage.getValueAsDouble();
         inputs.intakeCurrentAmps = intakeCurrent.getValueAsDouble();
         inputs.intakeVelocityRPM = intakeVelocity.getValueAsDouble() * 60;

--- a/src/main/java/org/team1540/robot2024/subsystems/shooter/FlywheelsIO.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/shooter/FlywheelsIO.java
@@ -9,11 +9,13 @@ public interface FlywheelsIO {
         public double leftCurrentAmps = 0.0;
         public double leftVelocityRPM = 0.0;
         public double leftTempCelsius = 0.0;
+        public boolean leftMotorConnected = true;
 
         public double rightAppliedVolts = 0.0;
         public double rightCurrentAmps = 0.0;
         public double rightVelocityRPM = 0.0;
         public double rightTempCelsius = 0.0;
+        public boolean rightMotorConnected = true;
     }
 
     /**

--- a/src/main/java/org/team1540/robot2024/subsystems/shooter/FlywheelsIOTalonFX.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/shooter/FlywheelsIOTalonFX.java
@@ -78,15 +78,16 @@ public class FlywheelsIOTalonFX implements FlywheelsIO {
 
     @Override
     public void updateInputs(FlywheelsIOInputs inputs) {
-        BaseStatusSignal.refreshAll(
+        inputs.leftMotorConnected = BaseStatusSignal.refreshAll(
                 leftVelocity,
                 leftAppliedVolts,
                 leftCurrent,
-                leftTempCelsius,
+                leftTempCelsius).isOK();
+        inputs.rightMotorConnected = BaseStatusSignal.refreshAll(
                 rightVelocity,
                 rightAppliedVolts,
                 rightCurrent,
-                rightTempCelsius);
+                rightTempCelsius).isOK();
 
         inputs.leftVelocityRPM = leftVelocity.getValueAsDouble() * 60;
         inputs.leftAppliedVolts = leftAppliedVolts.getValueAsDouble();

--- a/src/main/java/org/team1540/robot2024/subsystems/shooter/Shooter.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/shooter/Shooter.java
@@ -11,6 +11,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
 import org.team1540.robot2024.Constants;
+import org.team1540.robot2024.util.Alert;
 import org.team1540.robot2024.util.LoggedTunableNumber;
 import org.team1540.robot2024.util.MechanismVisualiser;
 import org.team1540.robot2024.util.math.AverageFilter;
@@ -32,6 +33,11 @@ public class Shooter extends SubsystemBase {
     private final AverageFilter leftSpeedFilter = new AverageFilter(20); // Units: RPM
     private final AverageFilter rightSpeedFilter = new AverageFilter(20); // Units: RPM
     private final AverageFilter pivotPositionFilter = new AverageFilter(10); // Units: rotations
+
+    private final Alert leftFlywheelDisconnected = new Alert("Left flywheel disconnected!", Alert.AlertType.WARNING);
+    private final Alert rightFlywheelDisconnected = new Alert("Right flywheel disconnected!", Alert.AlertType.WARNING);
+    private final Alert pivotMotorDisconnected = new Alert("Pivot motor disconnected!", Alert.AlertType.WARNING);
+    private final Alert pivotEncoderDisconnected = new Alert("Pivot encoder disconnected!", Alert.AlertType.WARNING);
 
     private double leftFlywheelSetpointRPM;
     private double rightFlywheelSetpointRPM;
@@ -126,6 +132,11 @@ public class Shooter extends SubsystemBase {
         pivotPositionFilter.add(getPivotPosition().getRotations());
         Logger.recordOutput("Shooter/Pivot/Error", pivotSetpoint.getDegrees() - pivotInputs.position.getDegrees());
         Logger.recordOutput("Shooter/Pivot/ResettingToCancoder", flipper);
+
+        leftFlywheelDisconnected.set(!flywheelInputs.leftMotorConnected);
+        rightFlywheelDisconnected.set(!flywheelInputs.rightMotorConnected);
+        pivotMotorDisconnected.set(!pivotInputs.motorConnected);
+        pivotEncoderDisconnected.set(!pivotInputs.encoderConnected);
     }
 
     /**

--- a/src/main/java/org/team1540/robot2024/subsystems/shooter/ShooterPivotIO.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/shooter/ShooterPivotIO.java
@@ -14,6 +14,8 @@ public interface ShooterPivotIO {
         public double tempCelsius = 0.0;
         public boolean isAtForwardLimit = false;
         public boolean isAtReverseLimit = false;
+        public boolean motorConnected = true;
+        public boolean encoderConnected = true;
     }
 
     /**

--- a/src/main/java/org/team1540/robot2024/subsystems/shooter/ShooterPivotIOTalonFX.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/shooter/ShooterPivotIOTalonFX.java
@@ -95,7 +95,15 @@ public class ShooterPivotIOTalonFX implements ShooterPivotIO {
 
     @Override
     public void updateInputs(ShooterPivotIOInputs inputs) {
-        BaseStatusSignal.refreshAll(position, absolutePosition, velocity, appliedVoltage, current, temp, forwardLimit, reverseLimit);
+        inputs.motorConnected = BaseStatusSignal.refreshAll(
+                position,
+                velocity,
+                appliedVoltage,
+                current,
+                temp,
+                forwardLimit,
+                reverseLimit).isOK();
+        inputs.encoderConnected = BaseStatusSignal.refreshAll(absolutePosition).isOK();
         inputs.isAtForwardLimit = forwardLimit.getValue() == ForwardLimitValue.ClosedToGround;
         inputs.isAtReverseLimit = reverseLimit.getValue() == ReverseLimitValue.ClosedToGround;
         inputs.position = Rotation2d.fromRotations(position.getValueAsDouble());

--- a/src/main/java/org/team1540/robot2024/subsystems/tramp/TrampIO.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/tramp/TrampIO.java
@@ -12,6 +12,7 @@ public interface TrampIO {
         public double currentAmps = 0.0;
         public double positionRots = 0.0;
         public double tempCelsius = 0.0;
+        public boolean motorConnected = true;
     }
 
     default void setVoltage(double volts) {}

--- a/src/main/java/org/team1540/robot2024/subsystems/tramp/TrampIOTalonFX.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/tramp/TrampIOTalonFX.java
@@ -44,7 +44,7 @@ public class TrampIOTalonFX implements TrampIO {
 
     @Override
     public void updateInputs(TrampIOInputs inputs) {
-        BaseStatusSignal.refreshAll(position, velocity, appliedVoltage, current, temp);
+        inputs.motorConnected = BaseStatusSignal.refreshAll(position, velocity, appliedVoltage, current, temp).isOK();
         inputs.noteInTramp = !(beamBreak.get());
         inputs.velocityRPM = velocity.getValueAsDouble() * 60;
         inputs.positionRots = position.getValueAsDouble();

--- a/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVision.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVision.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.Logger;
 import org.team1540.robot2024.Constants;
+import org.team1540.robot2024.util.Alert;
 import org.team1540.robot2024.util.vision.EstimatedVisionPose;
 
 import java.util.function.Consumer;
@@ -28,6 +29,11 @@ public class AprilTagVision extends SubsystemBase {
 
     private final EstimatedVisionPose frontPose = new EstimatedVisionPose();
     private final EstimatedVisionPose rearPose = new EstimatedVisionPose();
+
+    private final Alert frontCameraDisconnected =
+            new Alert("Front (tramp) camera disconnected!", Alert.AlertType.WARNING);
+    private final Alert rearCameraDisconnected =
+            new Alert("Rear (shooter) camera disconnected!", Alert.AlertType.WARNING);
 
     private static boolean hasInstance = false;
 
@@ -116,6 +122,9 @@ public class AprilTagVision extends SubsystemBase {
                                     DriverStation.getMatchNumber(),
                                     (int) Timer.getFPGATimestamp())));
         }
+
+        frontCameraDisconnected.set(!frontCameraInputs.connected);
+        rearCameraDisconnected.set(!rearCameraInputs.connected);
     }
 
     public void takeSnapshot(String snapshotName) {

--- a/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVisionIO.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVisionIO.java
@@ -11,6 +11,8 @@ public interface AprilTagVisionIO {
         public int[] seenTagIDs = new int[0];
         public double avgTagDistance = Double.POSITIVE_INFINITY;
         public double lastMeasurementTimestampSecs = 0.0;
+
+        public boolean connected = true;
     }
 
     default void updateInputs(AprilTagVisionIOInputs inputs) {}

--- a/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVisionIOLimelight.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVisionIOLimelight.java
@@ -1,15 +1,22 @@
 package org.team1540.robot2024.subsystems.vision;
 
 import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.Timer;
 import org.team1540.robot2024.util.vision.LimelightHelpers;
 
 import java.util.Arrays;
 
 public class AprilTagVisionIOLimelight implements AprilTagVisionIO {
     private final String name;
+    private final NetworkTable table;
+    private long lastHeartbeat;
+    private double lastHeartbeatChangeTime;
 
     public AprilTagVisionIOLimelight(String name, Pose3d cameraOffsetMeters) {
         this.name = name;
+        this.table = NetworkTableInstance.getDefault().getTable(name);
         LimelightHelpers.setCameraMode_Processor(name);
         LimelightHelpers.setLEDMode_PipelineControl(name);
         setPoseOffset(cameraOffsetMeters);
@@ -30,6 +37,14 @@ public class AprilTagVisionIOLimelight implements AprilTagVisionIO {
         inputs.numTagsSeen = measurement.tagCount;
         inputs.seenTagIDs = Arrays.stream(measurement.rawFiducials).mapToInt(fiducial -> fiducial.id).toArray();
         inputs.avgTagDistance = measurement.avgTagDist;
+
+        long hb = table.getEntry("hb").getInteger(0);
+        double currentTime = Timer.getFPGATimestamp();
+        if (hb > lastHeartbeat) {
+            lastHeartbeatChangeTime = currentTime;
+            lastHeartbeat = hb;
+        }
+        inputs.connected = currentTime - lastHeartbeatChangeTime < 0.5;
     }
 
     @Override

--- a/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVisionIOMegaTag2.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVisionIOMegaTag2.java
@@ -2,7 +2,10 @@ package org.team1540.robot2024.subsystems.vision;
 
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
 import org.team1540.robot2024.util.vision.LimelightHelpers;
 
 import java.util.Arrays;
@@ -10,10 +13,15 @@ import java.util.function.Supplier;
 
 public class AprilTagVisionIOMegaTag2 implements AprilTagVisionIO {
     private final String name;
+    private final NetworkTable table;
+    private long lastHeartbeat;
+    private double lastHeartbeatChangeTime;
+
     private final Supplier<Rotation2d> heading;
 
     public AprilTagVisionIOMegaTag2(String name, Pose3d cameraOffsetMeters, Supplier<Rotation2d> heading) {
         this.name = name;
+        this.table = NetworkTableInstance.getDefault().getTable(name);
         this.heading = heading;
         LimelightHelpers.setCameraMode_Processor(name);
         LimelightHelpers.setLEDMode_PipelineControl(name);
@@ -37,6 +45,14 @@ public class AprilTagVisionIOMegaTag2 implements AprilTagVisionIO {
         inputs.numTagsSeen = measurement.tagCount;
         inputs.seenTagIDs = Arrays.stream(measurement.rawFiducials).mapToInt(fiducial -> fiducial.id).toArray();
         inputs.avgTagDistance = measurement.avgTagDist;
+
+        long hb = table.getEntry("hb").getInteger(0);
+        double currentTime = Timer.getFPGATimestamp();
+        if (hb > lastHeartbeat) {
+            lastHeartbeatChangeTime = currentTime;
+            lastHeartbeat = hb;
+        }
+        inputs.connected = currentTime - lastHeartbeatChangeTime < 0.5;
     }
 
     @Override

--- a/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVisionIOPhoton.java
+++ b/src/main/java/org/team1540/robot2024/subsystems/vision/AprilTagVisionIOPhoton.java
@@ -56,6 +56,8 @@ public class AprilTagVisionIOPhoton implements AprilTagVisionIO {
                 inputs.avgTagDistance += new Pose3d().plus(target.getBestCameraToTarget()).getTranslation().getNorm();
             inputs.avgTagDistance /= inputs.numTagsSeen;
         }
+
+        inputs.connected = camera.isConnected();
     }
 
     @Override

--- a/src/main/java/org/team1540/robot2024/util/Alert.java
+++ b/src/main/java/org/team1540/robot2024/util/Alert.java
@@ -1,0 +1,139 @@
+package org.team1540.robot2024.util;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/** Class for managing persistent alerts to be sent over NetworkTables. */
+public class Alert {
+    private static final Map<String, SendableAlerts> groups = new HashMap<>();
+
+    private final AlertType type;
+    private boolean active = false;
+    private double activeStartTime = 0.0;
+    private String text;
+
+    /**
+     * Creates a new Alert in the default group - "Alerts". If this is the first to be instantiated,
+     * the appropriate entries will be added to NetworkTables.
+     *
+     * @param text Text to be displayed when the alert is active.
+     * @param type Alert level specifying urgency.
+     */
+    public Alert(String text, AlertType type) {
+        this("Alerts", text, type);
+    }
+
+    /**
+     * Creates a new Alert. If this is the first to be instantiated in its group, the appropriate
+     * entries will be added to NetworkTables.
+     *
+     * @param group Group identifier, also used as NetworkTables title
+     * @param text Text to be displayed when the alert is active.
+     * @param type Alert level specifying urgency.
+     */
+    public Alert(String group, String text, AlertType type) {
+        if (!groups.containsKey(group)) {
+            groups.put(group, new SendableAlerts());
+            SmartDashboard.putData(group, groups.get(group));
+        }
+
+        this.text = text;
+        this.type = type;
+        groups.get(group).alerts.add(this);
+    }
+
+    /**
+     * Sets whether the alert should currently be displayed. When activated, the alert text will also
+     * be sent to the console.
+     */
+    public void set(boolean active) {
+        if (active && !this.active) {
+            activeStartTime = Timer.getFPGATimestamp();
+            switch (type) {
+                case ERROR:
+                    DriverStation.reportError(text, false);
+                    break;
+                case WARNING:
+                    DriverStation.reportWarning(text, false);
+                    break;
+                case INFO:
+                    System.out.println(text);
+                    break;
+            }
+        }
+        this.active = active;
+    }
+
+    /** Updates current alert text. */
+    public void setText(String text) {
+        if (active && !text.equals(this.text)) {
+            switch (type) {
+                case ERROR:
+                    DriverStation.reportError(text, false);
+                    break;
+                case WARNING:
+                    DriverStation.reportWarning(text, false);
+                    break;
+                case INFO:
+                    System.out.println(text);
+                    break;
+            }
+        }
+        this.text = text;
+    }
+
+    private static class SendableAlerts implements Sendable {
+        public final List<Alert> alerts = new ArrayList<>();
+
+        public String[] getStrings(AlertType type) {
+            Predicate<Alert> activeFilter = (Alert x) -> x.type == type && x.active;
+            Comparator<Alert> timeSorter =
+                    (Alert a1, Alert a2) -> (int) (a2.activeStartTime - a1.activeStartTime);
+            return alerts.stream()
+                    .filter(activeFilter)
+                    .sorted(timeSorter)
+                    .map((Alert a) -> a.text)
+                    .toArray(String[]::new);
+        }
+
+        @Override
+        public void initSendable(SendableBuilder builder) {
+            builder.setSmartDashboardType("Alerts");
+            builder.addStringArrayProperty("errors", () -> getStrings(AlertType.ERROR), null);
+            builder.addStringArrayProperty("warnings", () -> getStrings(AlertType.WARNING), null);
+            builder.addStringArrayProperty("infos", () -> getStrings(AlertType.INFO), null);
+        }
+    }
+
+    /** Represents an alert's level of urgency. */
+    public enum AlertType {
+        /**
+         * High priority alert - displayed first on the dashboard with a red "X" symbol. Use this type
+         * for problems which will seriously affect the robot's functionality and thus require immediate
+         * attention.
+         */
+        ERROR,
+
+        /**
+         * Medium priority alert - displayed second on the dashboard with a yellow "!" symbol. Use this
+         * type for problems which could affect the robot's functionality but do not necessarily require
+         * immediate attention.
+         */
+        WARNING,
+
+        /**
+         * Low priority alert - displayed last on the dashboard with a green "i" symbol. Use this type
+         * for problems which are unlikely to affect the robot's functionality, or any other alerts
+         * which do not fall under "ERROR" or "WARNING".
+         */
+        INFO
+    }
+}


### PR DESCRIPTION
Adds an alert display to the driver dashboard, allows drivers to see issues that the robot has detected (motor/camera disconnected, CAN bus disconnected, low battery, etc.). Only works on Elastic or Shuffleboard. Functionality of CAN error detection still needs to be to be tested on actual robot.

Alerts look like this:
![image](https://github.com/flamingchickens1540/robot2024/assets/114535782/8eec9541-a4de-47da-9252-352597c6a236)
